### PR TITLE
Fix of JBPM-9920. Added dispose() to the JBPMController

### DIFF
--- a/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/jbpm/JBPMController.java
+++ b/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/jbpm/JBPMController.java
@@ -40,6 +40,7 @@ import org.kie.test.util.db.DataSourceFactory;
 import org.kie.test.util.db.PoolingDataSourceWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.jbpm.services.task.impl.TaskDeadlinesServiceImpl;
 
 public class JBPMController {
 
@@ -158,6 +159,7 @@ public class JBPMController {
     public void clear() {
         clearCustomEntries();
         disposeRuntimeManager();
+        TaskDeadlinesServiceImpl.dispose();
     }
 
     public void tearDown() {


### PR DESCRIPTION
Adding TaskDeadlinesServiceImpl.dispose() to the JBPMController solves:
Java.lang.IllegalStateException: EntityManagerFactory is closed. For more details:
https://qe-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/TESTING/job/_upstream/job/processes/job/perf-jbpm-upstream/30/console

Need for this was introduced by:
https://github.com/kiegroup/jbpm/pull/2044