### PR TITLE
[RHPAM-4698] Benchmark test for task notifications

### DIFF
--- a/jbpm-benchmarks/kieserver-assets/src/main/resources/processes/HumanTaskNotification.bpmn2
+++ b/jbpm-benchmarks/kieserver-assets/src/main/resources/processes/HumanTaskNotification.bpmn2
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_c38t4NJQEDu0fPJHWfbi2g" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+  <bpmn2:itemDefinition id="_timerDurationItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__6A29A358-3A42-4F00-8935-84FF97DAA861_SkippableInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__6A29A358-3A42-4F00-8935-84FF97DAA861_PriorityInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__6A29A358-3A42-4F00-8935-84FF97DAA861_CommentInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__6A29A358-3A42-4F00-8935-84FF97DAA861_DescriptionInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__6A29A358-3A42-4F00-8935-84FF97DAA861_CreatedByInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__6A29A358-3A42-4F00-8935-84FF97DAA861_TaskNameInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__6A29A358-3A42-4F00-8935-84FF97DAA861_GroupIdInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__6A29A358-3A42-4F00-8935-84FF97DAA861_ContentInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__6A29A358-3A42-4F00-8935-84FF97DAA861_NotStartedReassignInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__6A29A358-3A42-4F00-8935-84FF97DAA861_NotCompletedReassignInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__6A29A358-3A42-4F00-8935-84FF97DAA861_NotStartedNotifyInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__6A29A358-3A42-4F00-8935-84FF97DAA861_NotCompletedNotifyInputXItem" structureRef="Object"/>
+  <bpmn2:collaboration id="_080696FA-0F81-4FB2-9466-D6B46CD49612" name="Default Collaboration">
+    <bpmn2:participant id="_117288BB-EF95-49AA-86CD-39EF0076EC68" name="Pool Participant" processRef="org.kie.perf.HumanTaskNotification"/>
+  </bpmn2:collaboration>
+  <bpmn2:process id="org.kie.perf.HumanTaskNotification" drools:packageName="org.jbpm" drools:version="1.0" drools:adHoc="false" name="timer" isExecutable="true" processType="Public">
+    <bpmn2:property id="timerDuration" itemSubjectRef="_timerDurationItem" name="timerDuration"/>
+    <bpmn2:sequenceFlow id="_55A9D1B9-43D3-4F2E-A0EF-75881F3FEE93" sourceRef="_6A29A358-3A42-4F00-8935-84FF97DAA861" targetRef="_4EB4840D-FE97-4E22-8861-6FF33C1DD31F"/>
+    <bpmn2:sequenceFlow id="_53774855-B738-43A6-9A43-C98F734F6456" sourceRef="processStartEvent" targetRef="_6A29A358-3A42-4F00-8935-84FF97DAA861"/>
+    <bpmn2:endEvent id="_4EB4840D-FE97-4E22-8861-6FF33C1DD31F">
+      <bpmn2:incoming>_55A9D1B9-43D3-4F2E-A0EF-75881F3FEE93</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:startEvent id="processStartEvent">
+      <bpmn2:outgoing>_53774855-B738-43A6-9A43-C98F734F6456</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:userTask id="_6A29A358-3A42-4F00-8935-84FF97DAA861" name="do">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[do]]></drools:metaValue>
+        </drools:metaData>
+        <drools:onEntry-script scriptFormat="http://www.java.com/java">
+          <drools:script><![CDATA[//System.out.println("Process started: " + kcontext.getProcessInstance().getId());]]></drools:script>
+        </drools:onEntry-script>
+        <drools:onExit-script scriptFormat="http://www.java.com/java">
+          <drools:script><![CDATA[//System.out.println("Task exit for process: " + kcontext.getProcessInstance().getId());]]></drools:script>
+        </drools:onExit-script>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_53774855-B738-43A6-9A43-C98F734F6456</bpmn2:incoming>
+      <bpmn2:outgoing>_55A9D1B9-43D3-4F2E-A0EF-75881F3FEE93</bpmn2:outgoing>
+      <bpmn2:ioSpecification>
+        <bpmn2:dataInput id="_6A29A358-3A42-4F00-8935-84FF97DAA861_TaskNameInputX" drools:dtype="Object" itemSubjectRef="__6A29A358-3A42-4F00-8935-84FF97DAA861_TaskNameInputXItem" name="TaskName"/>
+        <bpmn2:dataInput id="_6A29A358-3A42-4F00-8935-84FF97DAA861_NotCompletedNotifyInputX" drools:dtype="Object" itemSubjectRef="__6A29A358-3A42-4F00-8935-84FF97DAA861_NotCompletedNotifyInputXItem" name="NotCompletedNotify"/>
+        <bpmn2:dataInput id="_6A29A358-3A42-4F00-8935-84FF97DAA861_SkippableInputX" drools:dtype="Object" itemSubjectRef="__6A29A358-3A42-4F00-8935-84FF97DAA861_SkippableInputXItem" name="Skippable"/>
+        <bpmn2:inputSet>
+          <bpmn2:dataInputRefs>_6A29A358-3A42-4F00-8935-84FF97DAA861_TaskNameInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_6A29A358-3A42-4F00-8935-84FF97DAA861_NotCompletedNotifyInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_6A29A358-3A42-4F00-8935-84FF97DAA861_SkippableInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:targetRef>_6A29A358-3A42-4F00-8935-84FF97DAA861_TaskNameInputX</bpmn2:targetRef>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[dosomething]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_6A29A358-3A42-4F00-8935-84FF97DAA861_TaskNameInputX]]></bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:targetRef>_6A29A358-3A42-4F00-8935-84FF97DAA861_NotCompletedNotifyInputX</bpmn2:targetRef>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[[from:admin@test.org|tousers:|togroups:|toemails:process@test.org|replyTo:|subject:Task Notification Email|body:Automatic Notification for Task]@[#{timerDuration}]]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_6A29A358-3A42-4F00-8935-84FF97DAA861_NotCompletedNotifyInputX]]></bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:targetRef>_6A29A358-3A42-4F00-8935-84FF97DAA861_SkippableInputX</bpmn2:targetRef>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[true]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_6A29A358-3A42-4F00-8935-84FF97DAA861_SkippableInputX]]></bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:potentialOwner id="_c3-jENJQEDu0fPJHWfbi2g">
+        <bpmn2:resourceAssignmentExpression id="_c3-jEdJQEDu0fPJHWfbi2g">
+          <bpmn2:formalExpression>perfUser</bpmn2:formalExpression>
+        </bpmn2:resourceAssignmentExpression>
+      </bpmn2:potentialOwner>
+    </bpmn2:userTask>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram>
+    <bpmndi:BPMNPlane bpmnElement="org.kie.perf.HumanTaskNotification">
+      <bpmndi:BPMNShape id="shape__6A29A358-3A42-4F00-8935-84FF97DAA861" bpmnElement="_6A29A358-3A42-4F00-8935-84FF97DAA861">
+        <dc:Bounds height="80" width="100" x="195" y="135"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape_processStartEvent" bpmnElement="processStartEvent">
+        <dc:Bounds height="56" width="56" x="120" y="165"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__4EB4840D-FE97-4E22-8861-6FF33C1DD31F" bpmnElement="_4EB4840D-FE97-4E22-8861-6FF33C1DD31F">
+        <dc:Bounds height="56" width="56" x="392" y="34"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape_processStartEvent_to_shape__6A29A358-3A42-4F00-8935-84FF97DAA861" bpmnElement="_53774855-B738-43A6-9A43-C98F734F6456">
+        <di:waypoint x="135" y="180"/>
+        <di:waypoint x="245" y="175"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__6A29A358-3A42-4F00-8935-84FF97DAA861_to_shape__4EB4840D-FE97-4E22-8861-6FF33C1DD31F" bpmnElement="_55A9D1B9-43D3-4F2E-A0EF-75881F3FEE93">
+        <di:waypoint x="245" y="175"/>
+        <di:waypoint x="420" y="62"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters/>
+          <bpsim:ElementParameters elementRef="_6A29A358-3A42-4F00-8935-84FF97DAA861">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:UniformDistribution max="10" min="5"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters>
+              <bpsim:Availability>
+                <bpsim:FloatingParameter value="8"/>
+              </bpsim:Availability>
+              <bpsim:Quantity>
+                <bpsim:FloatingParameter value="1"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters>
+              <bpsim:UnitCost>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters elementRef="processStartEvent">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:UniformDistribution max="10" min="5"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_c38t4NJQEDu0fPJHWfbi2g</bpmn2:source>
+    <bpmn2:target>_c38t4NJQEDu0fPJHWfbi2g</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/jbpm-benchmarks/kieserver-performance-tests-jmh-manual/pom.xml
+++ b/jbpm-benchmarks/kieserver-performance-tests-jmh-manual/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jbpm</groupId>
     <artifactId>jbpm-benchmarks</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kieserver-performance-tests-jmh-manual</artifactId>

--- a/jbpm-benchmarks/kieserver-performance-tests-jmh-manual/src/main/java/org/jbpm/test/performance/scenario/load/LServerHumanTaskNotificationProcess.java
+++ b/jbpm-benchmarks/kieserver-performance-tests-jmh-manual/src/main/java/org/jbpm/test/performance/scenario/load/LServerHumanTaskNotificationProcess.java
@@ -1,0 +1,84 @@
+package org.jbpm.test.performance.scenario.load;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.jbpm.test.performance.kieserver.KieServerClient;
+import org.jbpm.test.performance.kieserver.constant.ProcessStorage;
+import org.jbpm.test.performance.kieserver.constant.UserStorage;
+import org.kie.server.api.model.instance.ProcessInstance;
+import org.kie.server.api.model.instance.TaskSummary;
+import org.kie.server.client.ProcessServicesClient;
+import org.kie.server.client.QueryServicesClient;
+import org.kie.server.client.UserTaskServicesClient;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@State(Scope.Benchmark)
+@Fork(value = 1, jvmArgs = {"-Xms2G", "-Xmx2G"})
+@Warmup(iterations = 1, time = 1)
+@Measurement(iterations = 1, time = 1)
+@Threads(1)
+public class LServerHumanTaskNotificationProcess {
+    // ! Must be overridden using -p from command line
+    @Param("")
+    public String remoteAPI;
+
+    private KieServerClient client;
+    private ProcessServicesClient processClient;
+    private UserTaskServicesClient taskClient;
+    private QueryServicesClient queryClient;
+
+    @Setup(Level.Iteration)
+    public void init() {
+        System.setProperty("remoteAPI", remoteAPI);
+
+        client = new KieServerClient();
+        processClient = client.getProcessClient();
+        taskClient = client.getTaskClient();
+        queryClient = client.getQueryClient();
+
+        // Single thread setup. Otherwise there will be a primary key violation when running parallel.
+        execute();
+    }
+
+    private void execute() {
+        // start process instance
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("timerDuration", new String("10d"));
+        long pid = processClient.startProcess(KieServerClient.containerId, ProcessStorage.HumanTaskNotification.getProcessDefinitionId(), params);
+
+        ProcessInstance plog = queryClient.findProcessInstanceById(pid);
+
+        if (plog == null || plog.getState() != org.kie.api.runtime.process.ProcessInstance.STATE_ACTIVE) {
+            throw new RuntimeException("Unexpected state for processInstance " + (plog!=null?plog.getState():""));
+        }
+    }
+
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    @Benchmark
+    public void AverageTime() {
+        execute();
+    }
+
+    @TearDown(Level.Iteration)
+    public void close() {
+
+    }
+}

--- a/jbpm-benchmarks/kieserver-performance-tests-jmh/src/main/java/org/jbpm/test/performance/kieserver/constant/ProcessStorage.java
+++ b/jbpm-benchmarks/kieserver-performance-tests-jmh/src/main/java/org/jbpm/test/performance/kieserver/constant/ProcessStorage.java
@@ -4,7 +4,7 @@ public enum ProcessStorage {
 
     HumanTask("org.kie.perf.HumanTask"), HumanTaskTimer("org.kie.perf.HumanTaskTimer"), GroupHumanTask("org.kie.perf.GroupHumanTask"), ParallelGatewayTwoTimes(
             "org.kie.perf.ParallelGatewayTwoTimes"), RuleTask("org.kie.perf.RuleTask"), StartEnd("org.kie.perf.StartEnd"), IntermediateTimer(
-            "org.kie.perf.IntermediateTimer");
+            "org.kie.perf.IntermediateTimer"), HumanTaskNotification("org.kie.perf.HumanTaskNotification");
 
     private String processDefinitionId;
 


### PR DESCRIPTION
This is a benchmark test that has to be run manually, as described in https://github.com/kiegroup/kie-benchmarks/pull/173

The additional test uses a simple process containing one human task with a notification at `#{timerDuration}`. The test starts the process with timerDuration set to 10d, and does not complete it, as the idea is to measure (and compare) the time it takes such a process if the database contains a high number of timers.

Local test results:

Test run with an empty DB (postgresql):
```
Benchmark                                        (remoteAPI)  Mode  Cnt  Score   Error  Units
LServerHumanTaskNotificationProcess.AverageTime         REST  avgt   10  0.401 ± 0.130   s/op
LServerHumanTaskTimerProcess.AverageTime                REST  avgt   10  0.769 ± 0.577   s/op
```

Test run with ~125k active process instances and timers:
```
Benchmark                                        (remoteAPI)  Mode  Cnt  Score   Error  Units
LServerHumanTaskNotificationProcess.AverageTime         REST  avgt   10  0.694 ± 0.070   s/op
LServerHumanTaskTimerProcess.AverageTime                REST  avgt   10  3.380 ± 0.461   s/op
```

Note: The increase in `LServerHumanTaskNotificationProcess.AverageTime` could be related to the issue highlighted in RHPAM-4698. However, the much more significant increase in `LServerHumanTaskTimerProcess.AverageTime` seems to be related to slow execution of the [UnescalatedStartDeadlinesByTaskId](https://github.com/kiegroup/jbpm/blob/main/jbpm-human-task/jbpm-human-task-jpa/src/main/resources/META-INF/Taskorm.xml#L1039) query triggered by the `CancelDeadlineCommand` and needs to be investigated further.
