### PR TITLE
Update `kiegroup` repository references to `apache`

### DIFF
--- a/.ci/jenkins/Jenkinsfile.branch
+++ b/.ci/jenkins/Jenkinsfile.branch
@@ -7,7 +7,7 @@ AGENT_LABEL="ubuntu"
 MVN_TOOL="maven_3.8.6"
 JDK_TOOL="jdk_11_latest"
 benchmarksRepo="kie-benchmarks"
-GIT_AUTHOR="kiegroup"
+GIT_AUTHOR="apache"
 TARGET_BRANCH="newBranch"
 
 pipeline {

--- a/.ci/jenkins/Jenkinsfile.branch
+++ b/.ci/jenkins/Jenkinsfile.branch
@@ -6,7 +6,7 @@ import org.kie.jenkins.MavenStagingHelper
 AGENT_LABEL="ubuntu"
 MVN_TOOL="maven_3.8.6"
 JDK_TOOL="jdk_11_latest"
-benchmarksRepo="kie-benchmarks"
+benchmarksRepo="incubator-kie-kie-benchmarks"
 GIT_AUTHOR="apache"
 TARGET_BRANCH="newBranch"
 

--- a/.ci/jenkins/Jenkinsfile.bump-up-version
+++ b/.ci/jenkins/Jenkinsfile.bump-up-version
@@ -3,7 +3,7 @@ import org.jenkinsci.plugins.workflow.libs.Library
 
 import org.kie.jenkins.MavenCommand
 
-def repoName = 'kie-benchmarks'
+def repoName = 'incubator-kie-kie-benchmarks'
 
 pipeline {
     agent {

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -2,10 +2,10 @@
 * This file is describing all the Jenkins jobs in the DSL format (see https://plugins.jenkins.io/job-dsl/)
 * needed by the Kogito pipelines.
 *
-* The main part of Jenkins job generation is defined into the https://github.com/apache/kogito-pipelines repository.
+* The main part of Jenkins job generation is defined into the https://github.com/apache/incubator-kie-kogito-pipelines repository.
 *
 * This file is making use of shared libraries defined in
-* https://github.com/apache/kogito-pipelines/tree/main/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl.
+* https://github.com/apache/incubator-kie-kogito-pipelines/tree/main/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl.
 */
 
 import org.kie.jenkins.jobdsl.model.JobType

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -2,10 +2,10 @@
 * This file is describing all the Jenkins jobs in the DSL format (see https://plugins.jenkins.io/job-dsl/)
 * needed by the Kogito pipelines.
 *
-* The main part of Jenkins job generation is defined into the https://github.com/kiegroup/kogito-pipelines repository.
+* The main part of Jenkins job generation is defined into the https://github.com/apache/kogito-pipelines repository.
 *
 * This file is making use of shared libraries defined in
-* https://github.com/kiegroup/kogito-pipelines/tree/main/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl.
+* https://github.com/apache/kogito-pipelines/tree/main/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl.
 */
 
 import org.kie.jenkins.jobdsl.model.JobType

--- a/.ci/jenkins/dsl/test.sh
+++ b/.ci/jenkins/dsl/test.sh
@@ -22,13 +22,13 @@ fi
 
 git_author="$(echo ${git_url} | awk -F"${git_server_url}" '{print $2}' | awk -F. '{print $1}'  | awk -F/ '{print $1}')"
 
-export DSL_DEFAULT_MAIN_CONFIG_FILE_REPO="${git_author}"/drools
-export DSL_DEFAULT_FALLBACK_MAIN_CONFIG_FILE_REPO=apache/drools
+export DSL_DEFAULT_MAIN_CONFIG_FILE_REPO="${git_author}"/incubator-kie-drools
+export DSL_DEFAULT_FALLBACK_MAIN_CONFIG_FILE_REPO=apache/incubator-kie-drools
 export DSL_DEFAULT_MAIN_CONFIG_FILE_PATH=.ci/jenkins/config/main.yaml
-export DSL_DEFAULT_BRANCH_CONFIG_FILE_REPO="${git_author}"/drools
+export DSL_DEFAULT_BRANCH_CONFIG_FILE_REPO="${git_author}"/incubator-kie-drools
 
 file=$(mktemp)
 # For more usage of the script, use ./test.sh -h
-curl -o ${file} https://raw.githubusercontent.com/apache/kogito-pipelines/main/dsl/seed/scripts/seed_test.sh
+curl -o ${file} https://raw.githubusercontent.com/apache/incubator-kie-kogito-pipelines/main/dsl/seed/scripts/seed_test.sh
 chmod u+x ${file}
 ${file} $@

--- a/.ci/jenkins/dsl/test.sh
+++ b/.ci/jenkins/dsl/test.sh
@@ -23,12 +23,12 @@ fi
 git_author="$(echo ${git_url} | awk -F"${git_server_url}" '{print $2}' | awk -F. '{print $1}'  | awk -F/ '{print $1}')"
 
 export DSL_DEFAULT_MAIN_CONFIG_FILE_REPO="${git_author}"/drools
-export DSL_DEFAULT_FALLBACK_MAIN_CONFIG_FILE_REPO=kiegroup/drools
+export DSL_DEFAULT_FALLBACK_MAIN_CONFIG_FILE_REPO=apache/drools
 export DSL_DEFAULT_MAIN_CONFIG_FILE_PATH=.ci/jenkins/config/main.yaml
 export DSL_DEFAULT_BRANCH_CONFIG_FILE_REPO="${git_author}"/drools
 
 file=$(mktemp)
 # For more usage of the script, use ./test.sh -h
-curl -o ${file} https://raw.githubusercontent.com/kiegroup/kogito-pipelines/main/dsl/seed/scripts/seed_test.sh
+curl -o ${file} https://raw.githubusercontent.com/apache/kogito-pipelines/main/dsl/seed/scripts/seed_test.sh
 chmod u+x ${file}
 ${file} $@


### PR DESCRIPTION
@jstastny-cz I added one more commit, see 2bb0a165e7ee1811cc48f3a8c82396b306f9e33f to fix the repository name. If I understood it correctly, it should reference the new repository name too. Otherwise it would still check out the kiegroup mirror.

- https://github.com/kiegroup/kogito-pipelines/pull/1078
- https://github.com/kiegroup/kogito-runtimes/pull/3223
- https://github.com/kiegroup/kogito-examples/pull/1806
- https://github.com/kiegroup/kogito-apps/pull/1877
- https://github.com/kiegroup/kogito-images/pull/1698
- https://github.com/kiegroup/kogito-operator/pull/1528
- https://github.com/kiegroup/kogito-serverless-operator/pull/250
- https://github.com/kiegroup/kogito-docs/pull/497
- https://github.com/kiegroup/drools/pull/5519
- https://github.com/kiegroup/drools-website/pull/269
- https://github.com/kiegroup/kie-benchmarks/pull/260
- https://github.com/asf-transfer/optaplanner/pull/2968
- https://github.com/kiegroup/optaplanner-quickstarts/pull/601