### PR TITLE
kie-issues#667: fix cleanup and settingsXml handling

### DIFF
--- a/.ci/jenkins/Jenkinsfile.branch
+++ b/.ci/jenkins/Jenkinsfile.branch
@@ -14,7 +14,7 @@ pipeline {
     agent {
         label "$AGENT_LABEL"
     }
-    options{
+    options {
         timestamps()
     }
     tools {
@@ -24,7 +24,7 @@ pipeline {
     stages {
         stage('CleanWorkspace') {
             steps {
-                cleanWs()
+                cleanWs(disableDeferredWipeout: true)
             }
         }
         stage('clone kie-benchmarks') {
@@ -34,27 +34,27 @@ pipeline {
                 }
             }
         }
-        stage('create new branch'){
-            steps{
-                dir("${WORKSPACE}/${benchmarksRepo}"){
-                    script{
+        stage('create new branch') {
+            steps {
+                dir("${WORKSPACE}/${benchmarksRepo}") {
+                    script {
                         githubscm.createBranch(NEW_BRANCH)
                     }
                 }
             }
         }
-        stage('push new branch'){
-            steps{
-                dir("${WORKSPACE}/${benchmarksRepo}"){
-                    script{
+        stage('push new branch') {
+            steps {
+                dir("${WORKSPACE}/${benchmarksRepo}") {
+                    script {
                         githubscm.pushObject('origin', NEW_BRANCH)
                     }
                 }
             }
         }
     }
-    post{
-        always{
+    post {
+        cleanup {
             cleanWs()
         }
     }

--- a/.ci/jenkins/Jenkinsfile.bump-up-version
+++ b/.ci/jenkins/Jenkinsfile.bump-up-version
@@ -26,7 +26,7 @@ pipeline {
         stage('Initialize') {
             steps {
                 script {
-                    cleanWs()
+                    cleanWs(disableDeferredWipeout: true)
 
                     dir("${repoName}") {
                         deleteDir()
@@ -52,8 +52,8 @@ pipeline {
             }
         }
     }
-    post{
-        always{
+    post {
+        cleanup {
             cleanWs()
         }
     }


### PR DESCRIPTION
apache/incubator-kie-issues#667

Fixing cleanup and settings.xml pipeline configuration to work correctly in ASF Jenkins.

* Deferred wipeout was causing issues when invoked in early stages
* Docker cleanup can't be done since the overall build is in docker container that uses the docker.sock from the host - it would attempt to erase itself.
* withSettingsXmlId shared library method does imply usage of a prohibited groovy method, thus replacing with explicit configFileProvider and passing as withSettingsXmlFile goes around that part of code. 

Complete list:
apache/incubator-kie-kogito-pipelines#1113
apache/incubator-kie-kogito-runtimes#3272
apache/incubator-kie-kogito-apps#1909
apache/incubator-kie-kogito-examples#1820
apache/incubator-kie-drools#5572
apache/incubator-kie-optaplanner#3010
apache/incubator-kie-optaplanner-quickstarts#613
apache/incubator-kie-kogito-docs#514
apache/incubator-kie-docs#4531
apache/incubator-kie-benchmarks#273