### PR TITLE
[incubator-kie-benchmarks-284] Remove GHA Java 11

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [11, 17]
+        java: [17]
       fail-fast: false
     steps:
       - name: Check  out Git repository


### PR DESCRIPTION
- https://github.com/apache/incubator-kie-benchmarks/issues/284
Now drools main is Java 17, so GHA Java 11 is not required. (Just fails now)
