### PR TITLE
kie-issues#776: automate PR merge into protected branches

### DIFF
--- a/.ci/jenkins/Jenkinsfile.bump-up-version
+++ b/.ci/jenkins/Jenkinsfile.bump-up-version
@@ -45,9 +45,7 @@ pipeline {
                         githubscm.createBranch(localBranch)
                         maven.mvnSetVersionProperty("version.org.${getUpdateRepoName()}", getVersion())
                         String prLink = commitAndCreatePR(commitMsg, localBranch, "${getTargetBranch()}")
-                        sh "git checkout ${getTargetBranch()}"
-                        mergeAndPush(prLink, "${getTargetBranch()}")
-                        githubscm.removeRemoteBranch('origin', localBranch, getGitAuthorPushCredsId())
+                        approveAndMergePR(prLink)
                     }
                 }
             }
@@ -96,13 +94,12 @@ String commitAndCreatePR(String commitMsg, String localBranch, String targetBran
     githubscm.setUserConfigFromCreds(getGitAuthorPushCredsId())
     githubscm.commitChanges(commitMsg)
     githubscm.pushObject('origin', localBranch, getGitAuthorPushCredsId())
-    return githubscm.createPR(commitMsg, prBody, targetBranch,getGitAuthorCredsId())
+    return githubscm.createPR(commitMsg, prBody, targetBranch, getGitAuthorCredsId())
 }
 
-void mergeAndPush(String prLink, String targetBranch) {
+void approveAndMergePR(String prLink) {
     if (prLink?.trim()) {
-        githubscm.mergePR(prLink, getGitAuthorCredsId())
-        githubscm.pushObject('origin', targetBranch, getGitAuthorPushCredsId())
+        githubscm.approvePR(prLink, getGitAuthorPushCredsId())
+        githubscm.mergePR(prLink, getGitAuthorPushCredsId())
     }
 }
-


### PR DESCRIPTION
Part of:
* apache/incubator-kie-issues#776

Other related PRs:
* apache/incubator-kie-kogito-pipelines#1194
* apache/incubator-kie-benchmarks#286
* apache/incubator-kie-docs#4536
* apache/incubator-kie-kogito-runtimes#3501
* apache/incubator-kie-kogito-apps#2047
* apache/incubator-kie-kogito-examples#1914
* apache/incubator-kie-kogito-docs#626
* apache/incubator-kie-drools#5927
* apache/incubator-kie-optaplanner#3083
* apache/incubator-kie-kogito-serverless-operator#462

Replacing old approach to merge PRs:  merge locally + push into remote

New behavior relies on gh cli directly to approve and merge PR.