### PR TITLE
Fix EvaluationContextImpl constructor compilation errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
+# Maven Shade Plugin generated files
+dependency-reduced-pom.xml
+
 # Eclipse, Netbeans and IntelliJ files
 /.*
 !.gitignore

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/ast/AbstractASTBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/ast/AbstractASTBenchmark.java
@@ -20,11 +20,13 @@
 package org.drools.benchmarks.dmn.ast;
 
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.kie.dmn.api.core.DMNVersion;
 import org.kie.dmn.feel.lang.EvaluationContext;
 import org.kie.dmn.feel.lang.FEELDialect;
 import org.kie.dmn.feel.lang.Type;
 import org.kie.dmn.feel.lang.ast.BaseNode;
 import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
+import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
 import org.kie.dmn.feel.parser.feel11.ASTBuilderVisitor;
 import org.kie.dmn.feel.parser.feel11.FEELParser;
 import org.kie.dmn.feel.parser.feel11.FEEL_1_1Parser;
@@ -66,7 +68,7 @@ public abstract class AbstractASTBenchmark {
 
     private static EvaluationContext newEmptyEvaluationContext() {
         // Defaulting FEELDialect to FEEL
-        return new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), null, FEELDialect.FEEL);
+        return new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), new FEELEventListenersManager(), FEELDialect.FEEL, DMNVersion.V1_5);
     }
 
     private static BaseNode getBaseNode(String baseNodeExpression) {

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/EvaluationContextImplBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/EvaluationContextImplBenchmark.java
@@ -21,8 +21,12 @@ package org.drools.benchmarks.dmn.feel;
 
 import java.util.concurrent.TimeUnit;
 
+import org.kie.dmn.api.core.DMNVersion;
 import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.FEELDialect;
 import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
+import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
+import org.kie.dmn.feel.util.ClassLoaderUtil;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Measurement;
@@ -44,7 +48,7 @@ public class EvaluationContextImplBenchmark {
 
     @Setup()
     public void setupFEEL() {
-        context = new EvaluationContextImpl(this.getClass().getClassLoader(), null, null);
+        context = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), new FEELEventListenersManager(), FEELDialect.FEEL, DMNVersion.V1_5);
         context.enterFrame();
         context.enterFrame();
         context.enterFrame();

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/infixexecutors/FEELAddExecutorBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/infixexecutors/FEELAddExecutorBenchmark.java
@@ -18,9 +18,12 @@
  */
 package org.drools.benchmarks.dmn.feel.infixexecutors;
 
+import org.kie.dmn.api.core.DMNVersion;
 import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.FEELDialect;
 import org.kie.dmn.feel.lang.ast.infixexecutors.AddExecutor;
 import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
+import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
 import org.kie.dmn.feel.util.ClassLoaderUtil;
 import org.openjdk.jmh.annotations.*;
 
@@ -47,7 +50,7 @@ public class FEELAddExecutorBenchmark {
     @Setup
     public void setup() {
         executor = AddExecutor.instance();
-        ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), null, null);
+        ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), new FEELEventListenersManager(), FEELDialect.FEEL, DMNVersion.V1_5);
         values = getObjectArray(argsType);
     }
 

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/infixexecutors/FEELAndExecutorBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/infixexecutors/FEELAndExecutorBenchmark.java
@@ -18,9 +18,12 @@
  */
 package org.drools.benchmarks.dmn.feel.infixexecutors;
 
+import org.kie.dmn.api.core.DMNVersion;
 import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.FEELDialect;
 import org.kie.dmn.feel.lang.ast.infixexecutors.AndExecutor;
 import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
+import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
 import org.kie.dmn.feel.util.ClassLoaderUtil;
 import org.openjdk.jmh.annotations.*;
 
@@ -47,7 +50,7 @@ public class FEELAndExecutorBenchmark {
     @Setup
     public void setup() {
         executor = AndExecutor.instance();
-        ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), null, null);
+        ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), new FEELEventListenersManager(), FEELDialect.FEEL, DMNVersion.V1_5);
         values = getBooleanArray(args);
     }
 

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/infixexecutors/FEELDivExecutorBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/infixexecutors/FEELDivExecutorBenchmark.java
@@ -18,9 +18,13 @@
  */
 package org.drools.benchmarks.dmn.feel.infixexecutors;
 
+import org.kie.dmn.api.core.DMNVersion;
+
 import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.FEELDialect;
 import org.kie.dmn.feel.lang.ast.infixexecutors.DivExecutor;
 import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
+import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
 import org.kie.dmn.feel.util.ClassLoaderUtil;
 import org.openjdk.jmh.annotations.*;
 
@@ -47,7 +51,7 @@ public class FEELDivExecutorBenchmark {
     @Setup
     public void setup() {
         executor = DivExecutor.instance();
-        ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), null, null);
+        ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), new FEELEventListenersManager(), FEELDialect.FEEL, DMNVersion.V1_5);
         values = getObjectArray(args);
     }
 

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/infixexecutors/FEELEqExecutorBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/infixexecutors/FEELEqExecutorBenchmark.java
@@ -18,9 +18,12 @@
  */
 package org.drools.benchmarks.dmn.feel.infixexecutors;
 
+import org.kie.dmn.api.core.DMNVersion;
 import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.FEELDialect;
 import org.kie.dmn.feel.lang.ast.infixexecutors.EqExecutor;
 import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
+import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
 import org.kie.dmn.feel.util.ClassLoaderUtil;
 import org.openjdk.jmh.annotations.*;
 
@@ -47,7 +50,7 @@ public class FEELEqExecutorBenchmark {
     @Setup
     public void setup() {
         executor = EqExecutor.instance();
-        ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), null, null);
+        ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), new FEELEventListenersManager(), FEELDialect.FEEL, DMNVersion.V1_5);
         values = getBooleanArray(args);
     }
 

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/infixexecutors/FEELGtExecutorBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/infixexecutors/FEELGtExecutorBenchmark.java
@@ -18,9 +18,13 @@
  */
 package org.drools.benchmarks.dmn.feel.infixexecutors;
 
+import org.kie.dmn.api.core.DMNVersion;
+
 import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.FEELDialect;
 import org.kie.dmn.feel.lang.ast.infixexecutors.GtExecutor;
 import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
+import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
 import org.kie.dmn.feel.util.ClassLoaderUtil;
 import org.openjdk.jmh.annotations.*;
 
@@ -47,7 +51,7 @@ public class FEELGtExecutorBenchmark {
     @Setup
     public void setup() {
         executor = GtExecutor.instance();
-        ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), null, null);
+        ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), new FEELEventListenersManager(), FEELDialect.FEEL, DMNVersion.V1_5);
         values = getBooleanArray(args);
     }
 

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/infixexecutors/FEELGteExecutorBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/infixexecutors/FEELGteExecutorBenchmark.java
@@ -18,9 +18,13 @@
  */
 package org.drools.benchmarks.dmn.feel.infixexecutors;
 
+import org.kie.dmn.api.core.DMNVersion;
+
 import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.FEELDialect;
 import org.kie.dmn.feel.lang.ast.infixexecutors.GteExecutor;
 import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
+import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
 import org.kie.dmn.feel.util.ClassLoaderUtil;
 import org.openjdk.jmh.annotations.*;
 
@@ -47,7 +51,7 @@ public class FEELGteExecutorBenchmark {
     @Setup
     public void setup() {
         executor = GteExecutor.instance();
-        ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), null, null);
+        ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), new FEELEventListenersManager(), FEELDialect.FEEL, DMNVersion.V1_5);
         values = getBooleanArray(args);
     }
 

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/infixexecutors/FEELLtExecutorBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/infixexecutors/FEELLtExecutorBenchmark.java
@@ -18,9 +18,13 @@
  */
 package org.drools.benchmarks.dmn.feel.infixexecutors;
 
+import org.kie.dmn.api.core.DMNVersion;
+
 import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.FEELDialect;
 import org.kie.dmn.feel.lang.ast.infixexecutors.LtExecutor;
 import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
+import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
 import org.kie.dmn.feel.util.ClassLoaderUtil;
 import org.openjdk.jmh.annotations.*;
 
@@ -47,7 +51,7 @@ public class FEELLtExecutorBenchmark {
     @Setup
     public void setup() {
         executor = LtExecutor.instance();
-        ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), null, null);
+        ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), new FEELEventListenersManager(), FEELDialect.FEEL, DMNVersion.V1_5);
         values = getBooleanArray(args);
     }
 

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/infixexecutors/FEELLteExecutorBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/infixexecutors/FEELLteExecutorBenchmark.java
@@ -18,9 +18,13 @@
  */
 package org.drools.benchmarks.dmn.feel.infixexecutors;
 
+import org.kie.dmn.api.core.DMNVersion;
+
 import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.FEELDialect;
 import org.kie.dmn.feel.lang.ast.infixexecutors.LteExecutor;
 import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
+import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
 import org.kie.dmn.feel.util.ClassLoaderUtil;
 import org.openjdk.jmh.annotations.*;
 
@@ -47,7 +51,7 @@ public class FEELLteExecutorBenchmark {
     @Setup
     public void setup() {
         executor = LteExecutor.instance();
-        ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), null, null);
+        ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), new FEELEventListenersManager(), FEELDialect.FEEL, DMNVersion.V1_5);
         values = getBooleanArray(args);
     }
 

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/infixexecutors/FEELMultExecutorBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/infixexecutors/FEELMultExecutorBenchmark.java
@@ -18,9 +18,12 @@
  */
 package org.drools.benchmarks.dmn.feel.infixexecutors;
 
+import org.kie.dmn.api.core.DMNVersion;
 import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.FEELDialect;
 import org.kie.dmn.feel.lang.ast.infixexecutors.MultExecutor;
 import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
+import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
 import org.kie.dmn.feel.util.ClassLoaderUtil;
 import org.openjdk.jmh.annotations.*;
 
@@ -47,7 +50,7 @@ public class FEELMultExecutorBenchmark {
     @Setup
     public void setup() {
         executor = MultExecutor.instance();
-        ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), null, null);
+        ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), new FEELEventListenersManager(), FEELDialect.FEEL, DMNVersion.V1_5);
         values = getObjectArray(args);
     }
 

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/infixexecutors/FEELNeExecutorBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/infixexecutors/FEELNeExecutorBenchmark.java
@@ -18,9 +18,13 @@
  */
 package org.drools.benchmarks.dmn.feel.infixexecutors;
 
+import org.kie.dmn.api.core.DMNVersion;
+
 import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.FEELDialect;
 import org.kie.dmn.feel.lang.ast.infixexecutors.NeExecutor;
 import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
+import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
 import org.kie.dmn.feel.util.ClassLoaderUtil;
 import org.openjdk.jmh.annotations.*;
 
@@ -47,7 +51,7 @@ public class FEELNeExecutorBenchmark {
     @Setup
     public void setup() {
         executor = NeExecutor.instance();
-        ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), null, null);
+        ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), new FEELEventListenersManager(), FEELDialect.FEEL, DMNVersion.V1_5);
         values = getBooleanArray(args);
     }
 

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/infixexecutors/FEELOrExecutorBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/infixexecutors/FEELOrExecutorBenchmark.java
@@ -18,9 +18,13 @@
  */
 package org.drools.benchmarks.dmn.feel.infixexecutors;
 
+import org.kie.dmn.api.core.DMNVersion;
+
 import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.FEELDialect;
 import org.kie.dmn.feel.lang.ast.infixexecutors.OrExecutor;
 import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
+import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
 import org.kie.dmn.feel.util.ClassLoaderUtil;
 import org.openjdk.jmh.annotations.*;
 
@@ -47,7 +51,7 @@ public class FEELOrExecutorBenchmark {
     @Setup
     public void setup() {
         executor = OrExecutor.instance();
-        ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), null, null);
+        ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), new FEELEventListenersManager(), FEELDialect.FEEL, DMNVersion.V1_5);
         values = getBooleanArray(args);
     }
 

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/infixexecutors/FEELPowExecutorBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/infixexecutors/FEELPowExecutorBenchmark.java
@@ -18,9 +18,13 @@
  */
 package org.drools.benchmarks.dmn.feel.infixexecutors;
 
+import org.kie.dmn.api.core.DMNVersion;
+
 import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.FEELDialect;
 import org.kie.dmn.feel.lang.ast.infixexecutors.PowExecutor;
 import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
+import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
 import org.kie.dmn.feel.util.ClassLoaderUtil;
 import org.openjdk.jmh.annotations.*;
 
@@ -47,7 +51,7 @@ public class FEELPowExecutorBenchmark {
     @Setup
     public void setup() {
         executor = PowExecutor.instance();
-        ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), null, null);
+        ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), new FEELEventListenersManager(), FEELDialect.FEEL, DMNVersion.V1_5);
         values = getObjectArray(argsType);
     }
 

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/infixexecutors/FEELSubExecutorBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/infixexecutors/FEELSubExecutorBenchmark.java
@@ -18,9 +18,12 @@
  */
 package org.drools.benchmarks.dmn.feel.infixexecutors;
 
+import org.kie.dmn.api.core.DMNVersion;
 import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.FEELDialect;
 import org.kie.dmn.feel.lang.ast.infixexecutors.SubExecutor;
 import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
+import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
 import org.kie.dmn.feel.util.ClassLoaderUtil;
 import org.openjdk.jmh.annotations.*;
 
@@ -47,7 +50,7 @@ public class FEELSubExecutorBenchmark {
     @Setup
     public void setup() {
         executor = SubExecutor.instance();
-        ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), null, null);
+        ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), new FEELEventListenersManager(), FEELDialect.FEEL, DMNVersion.V1_5);
         values = getObjectArray(argsType);
     }
 


### PR DESCRIPTION
https://github.com/apache/incubator-kie-issues/issues/2175


Updated EvaluationContextImpl instantiation across DMN FEEL benchmark classes to use the correct constructor signature with FEELEventListenersManager, FEELDialect, and DMNVersion parameters. Also added dependency-reduced-pom.xml to .gitignore to exclude Maven Shade Plugin generated files.