### PR TITLE
[incubator-kie-benchmarks-297] Enable exec-model benchmark for KBaseC…

### DIFF
--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/AbstractBuildtimeBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/AbstractBuildtimeBenchmark.java
@@ -22,6 +22,9 @@ package org.drools.benchmarks.turtle.buildtime;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
+import org.drools.compiler.kie.builder.impl.DrlProject;
+import org.drools.model.codegen.ExecutableModelProject;
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieFileSystem;
@@ -69,21 +72,33 @@ public abstract class AbstractBuildtimeBenchmark {
      *
      * @return number of packages in the kbase
      */
-    protected int actuallyCreateTheKBase() {
+    protected int actuallyCreateTheKBase(boolean useCanonicalModel) {
         KieHelper kieHelper = new KieHelper();
         for (Resource resource : resources) {
             kieHelper.addResource(resource);
         }
-        KieBase kieBase = kieHelper.build();
+        KieBase kieBase;
+        if (useCanonicalModel) {
+            kieBase = kieHelper.build(ExecutableModelProject.class);
+        } else {
+            kieBase = kieHelper.build(DrlProject.class);
+        }
         int nrOfPackages = kieBase.getKiePackages().size();
         return nrOfPackages;
+    }
+
+    protected int actuallyCreateTheKBase() {
+        return actuallyCreateTheKBase(false);
     }
 
     /**
      * Builds resources without creating the KieBase.
      */
-    protected void buildResourcesWithoutKieBase(final Blackhole eater) {
-        eater.consume(KieServices.get().newKieBuilder(kieFileSystem).buildAll());
+    protected void buildResourcesWithoutKieBase(final Blackhole eater, boolean useCanonicalModel) {
+        if (useCanonicalModel) {
+            eater.consume(KieServices.get().newKieBuilder(kieFileSystem).buildAll(ExecutableModelProject.class));
+        } else {
+            eater.consume(KieServices.get().newKieBuilder(kieFileSystem).buildAll(DrlProject.class));
+        }
     }
-
 }

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/BuildDRLWithoutKieBaseBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/BuildDRLWithoutKieBaseBenchmark.java
@@ -29,6 +29,9 @@ import org.openjdk.jmh.infra.Blackhole;
  */
 public class BuildDRLWithoutKieBaseBenchmark extends AbstractBuildtimeBenchmark {
 
+    @Param({"true", "false"})
+    private boolean useCanonicalModel;
+
     @Param({"5k", "10k"})
     private String nrOfRules;
 
@@ -40,7 +43,7 @@ public class BuildDRLWithoutKieBaseBenchmark extends AbstractBuildtimeBenchmark 
 
     @Benchmark
     public void timeKBaseCreationFromDrl(final Blackhole eater) {
-        buildResourcesWithoutKieBase(eater);
+        buildResourcesWithoutKieBase(eater, useCanonicalModel);
     }
 
 }

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/KBaseCreationFromDrlBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/KBaseCreationFromDrlBenchmark.java
@@ -30,6 +30,9 @@ import org.openjdk.jmh.annotations.Setup;
  */
 public class KBaseCreationFromDrlBenchmark extends AbstractBuildtimeBenchmark {
 
+    @Param({"true", "false"})
+    private boolean useCanonicalModel;
+
     @Param({"1k", "5k", "10k"})
     private String nrOfRules;
 
@@ -40,7 +43,7 @@ public class KBaseCreationFromDrlBenchmark extends AbstractBuildtimeBenchmark {
 
     @Benchmark
     public int timeKBaseCreationFromDrl() {
-        return actuallyCreateTheKBase();
+        return actuallyCreateTheKBase(useCanonicalModel);
     }
 
 }

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/resources/kbase-creation/drl-kbase-creation-10k.drl
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/resources/kbase-creation/drl-kbase-creation-10k.drl
@@ -1,6 +1,7 @@
 package org.drools.benchmarks.bre;
 
 import java.util.Date;
+import java.util.ArrayList;
 
 import org.drools.benchmarks.common.model.Account;
 import org.drools.benchmarks.common.model.Address;
@@ -9,7 +10,7 @@ import org.drools.benchmarks.common.model.event.NewCustomerEvent;
 import org.drools.benchmarks.common.model.Transaction;
 import org.drools.benchmarks.common.model.event.TransactionCreatedEvent;
 
-global java.util.ArrayList list;
+global ArrayList list;
 
 
 rule "accountBalance0"

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/resources/kbase-creation/drl-kbase-creation-1k.drl
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/resources/kbase-creation/drl-kbase-creation-1k.drl
@@ -1,6 +1,7 @@
 package org.drools.benchmarks.bre;
 
 import java.util.Date;
+import java.util.ArrayList;
 
 import org.drools.benchmarks.common.model.Account;
 import org.drools.benchmarks.common.model.Address;
@@ -9,7 +10,7 @@ import org.drools.benchmarks.common.model.event.NewCustomerEvent;
 import org.drools.benchmarks.common.model.Transaction;
 import org.drools.benchmarks.common.model.event.TransactionCreatedEvent;
 
-global java.util.ArrayList list;
+global ArrayList list;
 
 
 rule "accountBalance0"

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/resources/kbase-creation/drl-kbase-creation-5k.drl
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/resources/kbase-creation/drl-kbase-creation-5k.drl
@@ -1,6 +1,7 @@
 package org.drools.benchmarks.bre;
 
 import java.util.Date;
+import java.util.ArrayList;
 
 import org.drools.benchmarks.common.model.Account;
 import org.drools.benchmarks.common.model.Address;
@@ -9,7 +10,7 @@ import org.drools.benchmarks.common.model.event.NewCustomerEvent;
 import org.drools.benchmarks.common.model.Transaction;
 import org.drools.benchmarks.common.model.event.TransactionCreatedEvent;
 
-global java.util.ArrayList list;
+global ArrayList list;
 
 
 rule "accountBalance0"

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/resources/kbase-creation/drl-template.drl
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/resources/kbase-creation/drl-template.drl
@@ -1,6 +1,7 @@
 package org.drools.benchmarks.bre;
 
 import java.util.Date;
+import java.util.ArrayList;
 
 import org.drools.benchmarks.common.model.Account;
 import org.drools.benchmarks.common.model.Address;
@@ -9,7 +10,7 @@ import org.drools.benchmarks.common.model.event.NewCustomerEvent;
 import org.drools.benchmarks.common.model.Transaction;
 import org.drools.benchmarks.common.model.event.TransactionCreatedEvent;
 
-global java.util.ArrayList list;
+global ArrayList list;
 <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 rule "accountBalance@RULE_NUMBER"


### PR DESCRIPTION
…reationFromDrlBenchmark and BuildDRLWithoutKieBaseBenchmark

Closes https://github.com/apache/incubator-kie-benchmarks/issues/297